### PR TITLE
Algo Debugging on Webserver

### DIFF
--- a/src/sailboat_interface/CMakeLists.txt
+++ b/src/sailboat_interface/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SailTail.msg"
   "srv/Waypoint.srv"
+  "msg/AlgoDebug.msg"
 
   DEPENDENCIES std_msgs sensor_msgs # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
 )

--- a/src/sailboat_interface/msg/AlgoDebug.msg
+++ b/src/sailboat_interface/msg/AlgoDebug.msg
@@ -1,0 +1,5 @@
+bool tacking
+sensor_msgs/NavSatFix tacking_point
+std_msgs/Int32 heading_dir
+sensor_msgs/NavSatFix curr_dest
+std_msgs/Int32 diff

--- a/src/sailboat_launch/config/config_sim.yaml
+++ b/src/sailboat_launch/config/config_sim.yaml
@@ -19,12 +19,13 @@ sailbot: #Namespace
 
    waypoint_service:
       ros__parameters:
-         waypoints:
-            - "65.473,232.01"
-            - "71.471,129.326"
-            - "81.099,86.541"
+             waypoints:
+               - "42.876379,-77.007822"
+               - "42.877381,-77.007830"
+               - "42.876394,-77.006820"
 
    main_algo:
       ros__parameters:
          tacking_buffer: 15
+         debug: True
 

--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -62,7 +62,6 @@ class MainAlgo(Node):
 
         # Publisher for rudder angle
         self.rudder_angle_pub = self.create_publisher(Int32, 'algo_rudder', 10)
-        self.tacking_point_pub = self.create_publisher(NavSatFix, 'tacking_point', 10)
 
         # Internal state
         self.wind_dir = None
@@ -159,7 +158,7 @@ class MainAlgo(Node):
         Use the NavSatFix data to assign value to self.curr_loc
         """
         # assuming the zone_number and zone_letter are the same for the current location and the destination
-        easting, northing, zone_number, zone_letter = utm.from_latlon(msg.longitude, msg.latitude)
+        easting, northing, zone_number, zone_letter = utm.from_latlon(msg.latitude, msg.longitude)
         self.curr_loc = Point()
         self.curr_loc.x = easting
         self.curr_loc.y = northing
@@ -284,11 +283,6 @@ class MainAlgo(Node):
             self.get_logger().error(f'Tacking point easting: {tp.x}, northing: {tp.y}')
             self.get_logger().error(f'Error in calculateTP: {str(e)}') 
             lat, long = 0., 0.
-        nav_sat_msg = NavSatFix()
-        nav_sat_msg.longitude = long
-        nav_sat_msg.latitude = lat
-        nav_sat_msg.position_covariance_type = 0
-        self.tacking_point_pub.publish(nav_sat_msg)
         self.get_logger().info('Tacking Point: ' + 'Lat: ' + str(nav_sat_msg.latitude) + ' Long: ' + str(nav_sat_msg.longitude))
 
 

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -209,4 +209,8 @@
         </div>
     </div>
     <script src="script.js"></script>
-    <script async defer src="https:            </div>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=key&callback=initMap">
+    </script>
+</body>
+
+</html>

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -93,6 +93,31 @@
                 </div>
             </div>
             <div class="table-container">
+                <h1>Algo Debugger</h1>
+                <div class="table">
+                    <div class="status-row">
+                        <span class="status-label">Tacking:</span>
+                        <span class="status-value" id="tacking-value">N/A</span>
+                    </div>
+                    <div class="status-row">
+                        <span class="status-label">Tacking Point:</span>
+                        <span class="status-value" id="tacking-point-value">N/A</span>
+                    </div>
+                    <div class="status-row">
+                        <span class="status-label">Heading Direction:</span>
+                        <span class="status-value" id="heading-dir-value">N/A</span>
+                    </div>
+                    <div class="status-row">
+                        <span class="status-label">Current Destination:</span>
+                        <span class="status-value" id="curr-dest-value">N/A</span>
+                    </div>
+                    <div class="status-row">
+                        <span class="status-label">Difference:</span>
+                        <span class="status-value" id="diff-value">N/A</span>
+                    </div>
+                </div>
+            </div>
+            <div class="table-container">
                 <h1>Connect to ROS</h1>
                 <div class="table">
                     <div class="status-row">
@@ -163,6 +188,7 @@
                     </div>
                 </div>
             </div>
+            
             <div id="sailboat-angle-dashboard">
                 <div class="dial">
                     <h3>Sail Angle</h3>
@@ -183,8 +209,4 @@
         </div>
     </div>
     <script src="script.js"></script>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=key&callback=initMap">
-    </script>
-</body>
-
-</html>
+    <script async defer src="https:            </div>

--- a/src/webserver/script.js
+++ b/src/webserver/script.js
@@ -321,6 +321,29 @@ function subscribeToTopics() {
         updateValue('actual-sail-angle-value', message.data);
         updateSailAngle(message.data, "actual-sail-angle-dial");
     });
+
+    const algoDebugTopic = new ROSLIB.Topic({
+        ros: ros,
+        name: '/sailbot/main_algo_debug',
+        messageType: 'sailboat_interface/msg/AlgoDebug',
+        throttle_rate: BASE_THROTTLE_RATE,
+    });
+    algoDebugTopic.subscribe(function (message) {
+        console.log("Algo debug")
+        // Extract and log the received data
+        const tacking = message.tacking;
+        const tackingPoint = message.tacking_point;
+        const headingDir = message.heading_dir.data;
+        const currDest = message.curr_dest;
+        const diff = message.diff.data;
+    
+        document.getElementById('tacking-value').innerText = tacking;
+        document.getElementById('tacking-point-value').innerText = `${tackingPoint.latitude.toFixed(6)}, ${tackingPoint.longitude.toFixed(6)}`;
+        document.getElementById('heading-dir-value').innerText = headingDir;
+        document.getElementById('curr-dest-value').innerText = `${currDest.latitude.toFixed(6)}, ${currDest.longitude.toFixed(6)}`;
+        document.getElementById('diff-value').innerText = diff;
+    });
+
     waypointService = new ROSLIB.Service({
         ros: ros,
         name: '/sailbot/mutate_waypoint_queue',


### PR DESCRIPTION
This PR allows us to better debug the sailing algo on the boat. Primarily addresses Issue #48 .

**Changes:**
1. New `AlgoDebug` msg in `sailboat_interface`, which holds:

```
> bool tacking
> sensor_msgs/NavSatFix tacking_point
> std_msgs/Int32 tack_time
> std_msgs/Int32 heading_dir
> sensor_msgs/NavSatFix curr_dest
> std_msgs/Int32 diff

```
This allows us to send all of the debugging info over one topic, which was convenient since it is only used on the webserver (and we don't want to pollute the namespace with a bunch of new topics)

2. New topic `sailbot/main_algo_debug` which sends an `AlgoDebug` message with the current state every ten seconds. This topic only exists if the `debug` flag in the config is sent to **true** (by default it is false). I've set it to be true in the `config_sim` config.

3. Updated the webserver to receive and read from this topic. It then presents the data in the new div. I put this data in a separate div because since this only sends while in debug mode, it may be useful to minimize it (as there is now a lot of info on the webserver). This is a future step brought up in Issue #50.

4. Adresses #52, changing default values for the waypoint queue to be valid latitude longitude pairs. 

5. Addresses #36 and #34 jointly; we now can convert freely between UTM and Lat/Long and it publishes on the webserver via the `AlgoDebug` message. Work needs to continue to show the results on google maps.

6. Also cleans up the main_algo (asserts certain invariants, does null checks to prevent failures, removes unecessary commented code). 

**Proof:**
<img width="469" alt="image" src="https://github.com/user-attachments/assets/fc2d772b-0db7-4773-adcc-e0cb0884ed02" />


**Please Squash my Commits if u merge!**


