### PR TITLE
Implement tacking point display, minimize status dashboard divs, clea…

### DIFF
--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -279,7 +279,7 @@ class MainAlgo(Node):
 
         assert tp.x < 900000 and tp.x > 100000, "Easting out of range"
 
-        # publish new TP if we do not not encounter an exception
+        # publish new TP if we do not encounter an exception
         try:
             lat, long = utm.to_latlon(tp.x, tp.y, self.zone_number, self.zone_letter)
             tacking_point_msg = NavSatFix()

--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -80,6 +80,9 @@ class MainAlgo(Node):
             # Timer to publish state every 1 second
             self.state_timer = self.create_timer(1.0, self.publish_state_debug)
 
+        # Publisher for tacking point
+        self.tacking_point_pub = self.create_publisher(NavSatFix, 'tacking_point', 10)
+
         self.request_new_waypoint()
         self.get_logger().info('Main-algo started successfully')  # Check if this line prints
 
@@ -276,9 +279,12 @@ class MainAlgo(Node):
 
         assert tp.x < 900000 and tp.x > 100000, "Easting out of range"
 
-        # publish new TP
+        # publish new TP if we do not not encounter an exception
         try:
             lat, long = utm.to_latlon(tp.x, tp.y, self.zone_number, self.zone_letter)
+            tacking_point_msg = NavSatFix()
+            tacking_point_msg.latitude, tacking_point_msg.longitude = lat, long
+            self.tacking_point_pub.publish(tacking_point_msg)
         except Exception as e: 
             self.get_logger().error(f'Tacking point easting: {tp.x}, northing: {tp.y}')
             self.get_logger().error(f'Error in calculateTP: {str(e)}') 

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -34,62 +34,78 @@
                         <span class="status-label">Control Mode:</span>
                         <span class="status-value" id="control-mode-value">N/A</span>
                     </div>
-                    <div class="status-row algo-mode">
-                        <span class="status-label">Algo Rudder:</span>
-                        <span class="status-value" id="algo-rudder-value">N/A</span>
-                    </div>
-                    <div class="status-row algo-mode">
-                        <span class="status-label">Algo Sail:</span>
-                        <span class="status-value" id="algo-sail-value">N/A</span>
-                    </div>
-                    <div class="status-row rc-mode">
-                        <span class="status-label">Radio Rudder:</span>
-                        <span class="status-value" id="radio-rudder-value">N/A</span>
-                    </div>
-                    <div class="status-row rc-mode">
-                        <span class="status-label">Radio Sail:</span>
-                        <span class="status-value" id="radio-sail-value">N/A</span>
+                    <div class="status-row">
+                        <span class="status-label">Sail Angle:</span>
+                        <span class="status-value" id="sail-value">N/A</span>
                     </div>
                     <div class="status-row">
                         <span class="status-label">Rudder Angle:</span>
                         <span class="status-value" id="rudder-angle-value">N/A</span>
                     </div>
-                    <div class="status-row">
-                        <span class="status-label">Sail:</span>
-                        <span class="status-value" id="sail-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label">Wind Angle: </span>
-                        <span class="status-value" id="wind-angle-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Sailboat Latitude: </span>
-                        <span class="status-value" id="latitude-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Sailboat Longitude: </span>
-                        <span class="status-value" id="longitude-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Actual Sail Angle: </span>
-                        <span class="status-value" id="actual-sail-angle-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Actual Tail Angle: </span>
-                        <span class="status-value" id="actual-tail-angle-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Dropped Packets: </span>
-                        <span class="status-value" id="dropped-packets-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Heading Angle: </span>
-                        <span class="status-value" id="heading-value">N/A</span>
-                    </div>
-                    <div class="status-row">
-                        <span class="status-label"> Rate of Turn (Z): </span>
-                        <span class="status-value" id="angular-velocity-z-value">N/A</span>
-                    </div>
+
+                    <details>
+                        <summary>Algo View</summary>
+                        <div class="status-row algo-mode">
+                            <span class="status-label">Algo Rudder:</span>
+                            <span class="status-value" id="algo-rudder-value">N/A</span>
+                        </div>
+                        <div class="status-row algo-mode">
+                            <span class="status-label">Algo Sail:</span>
+                            <span class="status-value" id="algo-sail-value">N/A</span>
+                        </div>
+                        <div class="status-row algo-mode">
+                            <span class="status-label">Tacking Point:</span>
+                            <span class="status-value" id="algo-sail-value">N/A</span>
+                        </div>
+                    </details>
+
+                    <details>
+                        <summary>RC View</summary>
+                        <div class="status-row rc-mode">
+                            <span class="status-label">Radio Rudder:</span>
+                            <span class="status-value" id="radio-rudder-value">N/A</span>
+                        </div>
+                        <div class="status-row rc-mode">
+                            <span class="status-label">Radio Sail:</span>
+                            <span class="status-value" id="radio-sail-value">N/A</span>
+                        </div>
+                    </details>
+
+                    <details>
+                        <summary>Sensor View</summary>
+                        <div class="status-row">
+                            <span class="status-label">Wind Angle: </span>
+                            <span class="status-value" id="wind-angle-value">N/A</span>
+                        </div>
+                        <div class="status-row">
+                            <span class="status-label">Heading Angle: </span>
+                            <span class="status-value" id="heading-value">N/A</span>
+                        </div>
+                        <div class="status-row">
+                            <span class="status-label">Sailboat Latitude: </span>
+                            <span class="status-value" id="latitude-value">N/A</span>
+                        </div>
+                        <div class="status-row">
+                            <span class="status-label">Sailboat Longitude: </span>
+                            <span class="status-value" id="longitude-value">N/A</span>
+                        </div>
+                    </details>
+
+                    <details>
+                        <summary>Teensy View</summary>
+                        <div class="status-row">
+                            <span class="status-label">Actual Sail Angle: </span>
+                            <span class="status-value" id="actual-sail-angle-value">N/A</span>
+                        </div>
+                        <div class="status-row">
+                            <span class="status-label">Actual Tail Angle: </span>
+                            <span class="status-value" id="actual-tail-angle-value">N/A</span>
+                        </div>
+                        <div class="status-row">
+                            <span class="status-label">Dropped Packets: </span>
+                            <span class="status-value" id="dropped-packets-value">N/A</span>
+                        </div>
+                    </details>
                 </div>
             </div>
             <div class="table-container">
@@ -131,45 +147,47 @@
                         <button type="button" id="connect-to-ros">Submit</button>
                     </div>
                 </div>
-                <h1>Waypoint & Buoy Input</h1>
             </div>
-            <div class="waypoint-buoy-container">
-                <div class="waypoint-buoy-table">
-                    <div class="status-row-input second">
-                        <span class="status-label">Latitude:</span>
-                        <div class="input-group">
-                            <input type="number" id="waypoint-latitude" name="latitude" inputmode="decimal"
-                                placeholder="Enter latitude" required>
+            <div class="table-container">
+                <h1>Waypoint & Buoy Input</h1>
+                <div class="waypoint-buoy-container">
+                    <div class="waypoint-buoy-table">
+                        <div class="status-row-input second">
+                            <span class="status-label">Latitude:</span>
+                            <div class="input-group">
+                                <input type="number" id="waypoint-latitude" name="latitude" inputmode="decimal"
+                                    placeholder="Enter latitude" required>
+                            </div>
+                        </div>
+                        <div class="status-row-input second">
+                            <span class="status-label">Longitude:</span>
+                            <div class="input-group">
+                                <input type="number" id="waypoint-longitude" name="longitude" inputmode="decimal"
+                                    placeholder="Enter longitude" required>
+                            </div>
+                        </div>
+                        <div class="button-group">
+                            <button type="button" id="submit-waypoint">Submit Waypoint</button>
                         </div>
                     </div>
-                    <div class="status-row-input second">
-                        <span class="status-label">Longitude:</span>
-                        <div class="input-group">
-                            <input type="number" id="waypoint-longitude" name="longitude" inputmode="decimal"
-                                placeholder="Enter longitude" required>
+                    <div class="waypoint-buoy-table">
+                        <div class="status-row-input second">
+                            <span class="status-label">Latitude:</span>
+                            <div class="input-group">
+                                <input type="number" id="buoy-latitude" name="latitude" inputmode="decimal"
+                                    placeholder="Enter latitude" required>
+                            </div>
                         </div>
-                    </div>
-                    <div class="button-group">
-                        <button type="button" id="submit-waypoint">Submit Waypoint</button>
-                    </div>
-                </div>
-                <div class="waypoint-buoy-table">
-                    <div class="status-row-input second">
-                        <span class="status-label">Latitude:</span>
-                        <div class="input-group">
-                            <input type="number" id="buoy-latitude" name="latitude" inputmode="decimal"
-                                placeholder="Enter latitude" required>
+                        <div class="status-row-input second">
+                            <span class="status-label">Longitude:</span>
+                            <div class="input-group">
+                                <input type="number" id="buoy-longitude" name="longitude" inputmode="decimal"
+                                    placeholder="Enter longitude" required>
+                            </div>
                         </div>
-                    </div>
-                    <div class="status-row-input second">
-                        <span class="status-label">Longitude:</span>
-                        <div class="input-group">
-                            <input type="number" id="buoy-longitude" name="longitude" inputmode="decimal"
-                                placeholder="Enter longitude" required>
+                        <div class="button-group">
+                            <button type="button" id="submit-buoy">Submit Buoy</button>
                         </div>
-                    </div>
-                    <div class="button-group">
-                        <button type="button" id="submit-buoy">Submit Buoy</button>
                     </div>
                 </div>
             </div>
@@ -188,7 +206,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div id="sailboat-angle-dashboard">
                 <div class="dial">
                     <h3>Sail Angle</h3>

--- a/src/webserver/script.js
+++ b/src/webserver/script.js
@@ -8,6 +8,7 @@ let waypoints = []; // Global array for storing waypoints
 const waypointMarkers = {}; // Global dictionary for waypoint markers
 let map; // Global variable for the map instance
 let sailboatMarker; // Global variable for the sailboat marker
+let tackingPointMarker; // Global variable for the tacking point marker
 
 let buoys = []
 const buoyMarkers = {};
@@ -143,7 +144,6 @@ function parseGpsData(message) {
 
 function parseImuData(message) {
     parseHeading(message);
-    // parseAngularVelocityData(message);
 }
 
 function parseHeading(message) {
@@ -163,35 +163,35 @@ function parseHeading(message) {
     }
 }
 
-// Not in use after changing quaternion to vector3 type
-// function parseAngularVelocityData(message) {
-//     angularVelocityZ = message.z;
+// Updates the tacking point on the map and UI
+function parseTackingPoint(message) {
+    // Update the UI with the tacking point lat/long
+    const formattedLatitude = message.latitude.toFixed(6);
+    const formattedLongitude = message.longitude.toFixed(6);
 
-//     angularVelocityZ = angularVelocityZ.toFixed(6);
+    document.getElementById('tacking-point-value').innerText = `${formattedLatitude}, ${formattedLongitude}`;
 
-//     document.getElementById('angular-velocity-z-value').innerText = angularVelocityZ
-// }
+    // Update the tacking point marker on the map
+    const tackingPointLocation = { lat: message.latitude, lng: message.longitude };
+    if (!tackingPointMarker) {
+        // Create a new marker if it doesn't exist
+        tackingPointMarker = new google.maps.Marker({
+            position: tackingPointLocation,
+            map: map,
+            title: "Tacking Point Location",
+            icon: {
+                path: google.maps.SymbolPath.CIRCLE,
+                scale: 8,
+                fillColor: "#0000FF",
+                fillOpacity: 1,
+                strokeWeight: 1,
+                strokeColor: "#FFFFFF"
+            }
+        });
+    } else {
+        tackingPointMarker.setPosition(tackingPointLocation);
+    }
 
-/**
- * Converts a quaternion to a heading angle in degrees.
- * @param {number} x - The x component of the quaternion.
- * @param {number} y - The y component of the quaternion.
- * @param {number} z - The z component of the quaternion.
- * @param {number} w - The w component of the quaternion.
- * @returns {number} The heading angle in degrees.
- */
-
-function quaternionToHeading(x, y, z, w) {
-    // Compute the heading angle (yaw) from the quaternion
-    const siny_cosp = 2 * (w * z + x * y);
-    const cosy_cosp = 1 - 2 * (y * y + z * z);
-    const headingRadians = Math.atan2(siny_cosp, cosy_cosp);
-
-    // Convert the heading from radians to degrees
-    const headingDegrees = headingRadians * (180 / Math.PI);
-
-    // Normalize to the range [0, 360)
-    return (headingDegrees + 360) % 360;
 }
 
 let waypointService;
@@ -322,6 +322,14 @@ function subscribeToTopics() {
         updateSailAngle(message.data, "actual-sail-angle-dial");
     });
 
+    const tackingPointTopic = new ROSLIB.Topic({
+        ros: ros,
+        name: '/sailbot/tacking_point',
+        messageType: 'sensor_msgs/NavSatFix',
+        throttle_rate: BASE_THROTTLE_RATE,
+    })
+    tackingPointTopic.subscribe(parseTackingPoint);
+
     const algoDebugTopic = new ROSLIB.Topic({
         ros: ros,
         name: '/sailbot/main_algo_debug',
@@ -336,7 +344,7 @@ function subscribeToTopics() {
         const headingDir = message.heading_dir.data;
         const currDest = message.curr_dest;
         const diff = message.diff.data;
-    
+
         document.getElementById('tacking-value').innerText = tacking;
         document.getElementById('tacking-point-value').innerText = `${tackingPoint.latitude.toFixed(6)}, ${tackingPoint.longitude.toFixed(6)}`;
         document.getElementById('heading-dir-value').innerText = headingDir;

--- a/src/webserver/styles.css
+++ b/src/webserver/styles.css
@@ -150,6 +150,10 @@ button {
     cursor: pointer;
 }
 
+button:hover {
+    background-color: #0056b3;
+}
+
 .dropdown-button {
     background-color: #007bff;
     color: white;
@@ -209,4 +213,15 @@ button {
     font-size: 16px;
     font-weight: bold;
     width: 200px;
+}
+
+details summary {
+    margin-bottom: 10px;
+    color: darkblue;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+details div {
+    margin-top: 10px;
 }


### PR DESCRIPTION
…nup and small improvements

Remade due to issues with the other branch/PR. 

UI/UX and quality of life improvements.

- To address https://github.com/CUSail-Navigation/sailbot/issues/50, the Sailboat Status Dashboard is split into sections. Buttons toggle hiding/showing the fields within each section.
- To address https://github.com/CUSail-Navigation/sailbot/issues/34, a tacking point publisher is added within main_algo.py. This topic is subscribed to within script.js. A maps marker is added following the format of the existing boat and buoy markers. A - "Tacking Point" field is also added to the Sailboat Status Dashboard.
- Also address https://github.com/CUSail-Navigation/sailbot/issues/49 by adding a wrapper div of class "table-container".
- Some commented code within script.js is removed
- Button's now turn dark blue upon hover

Proof:
The following screenshots show the webserver updating while the sailboat.launch_sim.py launch file runs. The blue dot in the second screenshot is the tacking point.

![Screenshot 2025-03-27 030055](https://github.com/user-attachments/assets/20c0f39b-4dc2-4237-8879-7768c781d7ae)
![Screenshot 2025-03-27 025831](https://github.com/user-attachments/assets/3e1e8a82-53e4-4609-9d50-bc8c236953b4)

Notes:

The algo currently crashes. To test tacking points being added to the map, the tacking point publishing was hardcoded into the main algo.
Heading does not update due to the airmar_node still having the conversion to quaternion.