### PR TITLE
Bugfix for main algo popping 2 points instead of one

### DIFF
--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -188,7 +188,7 @@ class MainAlgo(Node):
             if dist_to_dest < 5:
                 self.get_logger().info('=============================== Waypoint popped ===============================')
                 self.pop_waypoint()
-                self.dist_to_dest = None
+                self.curr_dest = None
 
         self.calculate_rudder_angle()
 

--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -188,6 +188,7 @@ class MainAlgo(Node):
             if dist_to_dest < 5:
                 self.get_logger().info('=============================== Waypoint popped ===============================')
                 self.pop_waypoint()
+                self.dist_to_dest = None
 
         self.calculate_rudder_angle()
 


### PR DESCRIPTION
Adressing #83:

**Solution:** Set  `self.curr_dest= None` after a pop
```
if self.curr_dest is not None:
            dist_to_dest = math.dist((self.curr_loc.x, self.curr_loc.y), (self.curr_dest.x, self.curr_dest.y))
            self.get_logger().info(f'Distance to destination: {dist_to_dest}')
            self.dist_to_dest = dist_to_dest
            # if we have reached our waypoint, pop it off 
            if dist_to_dest < 5:
                self.get_logger().info('=============================== Waypoint popped ===============================')
                self.pop_waypoint()
                self.curr_dest = None
```
This is the code now. We pop and then we set the state to None, such that a pop is impossible as the loop guard will evaluate to false until we get a new waypoint from the waypoint service.