### PR TITLE
change Point types to be new custom LatLong or UTM types 

### DIFF
--- a/src/sailboat_main/sailboat_main/main_algo/main_algo.py
+++ b/src/sailboat_main/sailboat_main/main_algo/main_algo.py
@@ -71,6 +71,7 @@ class UTMPoint():
         """
         Calculate the distance to another UTM point.
         """
+        assert self.zone_number == other.zone_number, "Zone numbers must be the same for distance calculation"
         return math.dist((self.easting, self.northing), (other.easting, other.northing))
 
     def __repr__(self):


### PR DESCRIPTION
Addressing #55.
This PR is to make some significant quality of life improvements and code readability changes in the MainAlgo, and *not to make any feature enhancements*. The main algo uses UTM in order to calculate distances assuming a Cartesian plane, and must readily convert between UTM and Cartesian coordinates. 

In order to remove duplicate code, get rid of the use of the Point class. The point class has x and y fields but no fields for the other UTM attributes like zone_number and zone_letter. When using a Point to represent Lat/Long, it becomes confusing to use y for Lat, and x for long. We thus create a `LatLongPoint` class and a `UTMPoint` class and wrap the `utm` conversion methods within these two classes. 

The internal state maintained by the MainAlgo holds the `self.curr_loc`, the `self.curr_dest`, and the `self.tacking_point` as `UTMPoints` as "enforced" by the type hinting. LatLong conversions are used primarily when receiving sensor data over topics, and when sending data over other topics to say, the webserver. Thus, we silo all use of UTM to only the MainAlgo.

A lot of minor work was also done to improve code cleanliness and improve type hinting. I also deleted some unused code like `euler_to_quaternion` that was making the algo file more complicated.

We also require that the zone numbers are the same to calculate destination
