### PR TITLE
Change Waypoint Service Default Initial to be Empty

### DIFF
--- a/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
+++ b/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
@@ -1,6 +1,5 @@
 import rclpy
 from rclpy.node import Node
-from std_msgs.msg import String
 from sensor_msgs.msg import NavSatFix
 import threading
 from sailboat_interface.srv import Waypoint

--- a/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
+++ b/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
@@ -20,7 +20,7 @@ class WaypointService(Node):
         self.waypoint_publisher = self.create_publisher(NavSatFix, 'current_waypoint', 10)
 
         # Get initial waypoints from config
-        self.declare_parameter('waypoints', ["0, 0"])  # Dummy initial
+        self.declare_parameter('waypoints', ["42.444235, -76.483628"])  # default initial, located in Eng Quad
         waypoints_param = self.get_parameter('waypoints').get_parameter_value().string_array_value
 
         self.waypoints = self.parse_waypoints_param(waypoints_param)

--- a/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
+++ b/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
@@ -20,11 +20,9 @@ class WaypointService(Node):
         self.waypoint_publisher = self.create_publisher(NavSatFix, 'current_waypoint', 10)
 
         # Get initial waypoints from config
-        self.declare_parameter('waypoints', ["42.444235, -76.483628"])  # default initial, located in Eng Quad
+        self.declare_parameter('waypoints', ["42.444235, -76.483628"]) # default initial, located in Eng Quad
         waypoints_param = self.get_parameter('waypoints').get_parameter_value().string_array_value
-
         self.waypoints = self.parse_waypoints_param(waypoints_param)
-        self.current_index = 0  # Index for the front of the waypoint queue
 
         self.publish_current_waypoint()
 
@@ -43,7 +41,7 @@ class WaypointService(Node):
         Publish the current waypoint (front of queue) as a NavSatFix message.
         Assumes coordinates are in latitude, longitude format.
         """
-        if not self.waypoints:
+        if self.waypoints == []:
             self.get_logger().warning("No waypoints to publish")
             return
             

--- a/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
+++ b/src/sailbot_events/sailbot_events/event_driver/waypoint_service.py
@@ -23,7 +23,7 @@ class WaypointService(Node):
         # Get initial waypoints from config
         self.declare_parameter('waypoints', [""], ParameterDescriptor(
             type=ParameterType.PARAMETER_STRING_ARRAY,
-            description="List of waypoints in the format 'lat,lon' separated by ';'. Example: '37.7749,-122.4194;37.7749,-122.4195'",
+            description="List of waypoints in the format 'lat,lon' separated by ',. Example: '37.7749,-122.4194,37.7749,-122.4195'",
         ))  # Default to an empty list if no waypoints are provided
         waypoints_param = self.get_parameter('waypoints').get_parameter_value().string_array_value
 


### PR DESCRIPTION
Addressing #44:

> We have a waypoint_service node. It maintains a list of waypoints in queue using a list of strings which are lat/long CSV vals. Currently it initializes with an initial value of ["0, 0"], which we call a "dummy initial." this is an issue because then the first value to the main algo is in a different UTM zone than the boat.


```python
# Get initial waypoints from config
self.declare_parameter('waypoints', [""], ParameterDescriptor(
    type=ParameterType.PARAMETER_STRING_ARRAY,
    description="List of waypoints in the format 'lat,lon' separated by ';'. Example: '37.7749,-122.4194;37.7749,-122.4195'",
))  # Default to an empty list if no waypoints are provided
waypoints_param = self.get_parameter('waypoints').get_parameter_value().string_array_value

# this is a workaround for if no defaults are set; ROS requires a parameter string array be non-empty when declaring a parameter
# but we want a default truly empty waypoint queue
self.waypoints = self.parse_waypoints_param(waypoints_param) if waypoints_param != [''] else []

self.publish_current_waypoint() # Publish the first waypoint if self.waypoints is non-empty
```
This is the meet of the code. If nothing is specified in config (the .yaml file), we use the default of ['']. The problem is that we actually want the default to be [], where there are no waypoints, because a list of an empty string is not logically equivalent to a proper empty list (which is the value used to by `publish_waypoint()` to check if there is a waypoint to publish to the main_algo. However, because of [this ROS issue](https://github.com/ros2/rclpy/issues/912), we cannot make the default a true empty list otherwise ROS throws an error (and it doesn't look like the ROS people are fixing it anytime soon). So we have a workaround of checking if there were any params in the config, and if there weren't, we set the waypoints to be an empty list afterwards. 

I checked the logic and it works both for a config with initial waypoints and without them, and also on the webserver. Note that if there are no initial waypoints, the main_algo won't do anything until a waypoint is added and publish_waypoint is called by the waypoint service to send the main_algo a waypoint over the `current_waypoint` topic. Then, the algo works as normal. I think this is a good behavior. 

Also deleted some unecessary state (the current waypoint index which is no longer used), and fixed some minor conditional statements for clarity.