### PR TITLE
Refactor mux for less duplicate code, add controller_app option

### DIFF
--- a/src/sailboat_main/sailboat_main/mux/mux_node.py
+++ b/src/sailboat_main/sailboat_main/mux/mux_node.py
@@ -1,121 +1,77 @@
 import rclpy
 from rclpy.node import Node
-from std_msgs.msg import Int32, String # Assuming the sail and rudder topics use Int32 messages
+from std_msgs.msg import Int32, String
 
 class MuxNode(Node):
     def __init__(self):
         super().__init__('mux_node')
 
+        # Default control mode
         self.declare_parameter('control_mode', 'algorithm')
         self.control_mode = self.get_parameter('control_mode').value
 
-        # Mux topic for changing control_mode topic
-        self.control_mode_sub = self.create_subscription(
-            String, 'control_mode', self.control_mode_callback, 10)
+        # Mux topic for changing control_mode
+        self.create_subscription(String, 'control_mode', self.control_mode_callback, 10)
 
-        # Subscribers for radio topics
-        self.radio_sail_sub = self.create_subscription(
-            Int32, 'radio_sail', self.radio_sail_callback, 10)
-        self.radio_rudder_sub = self.create_subscription(
-            Int32, 'radio_rudder', self.radio_rudder_callback, 10)
+        # Define control sources
+        self.control_sources = {
+            'radio': {'sail': None, 'rudder': None},
+            'algorithm': {'sail': None, 'rudder': None},
+            'webserver': {'sail': None, 'rudder': None},
+            'controller_app': {'sail': None, 'rudder': None}
+        }
 
-        # Subscribers for algorithm topics
-        self.algo_sail_sub = self.create_subscription(
-            Int32, 'algo_sail', self.algo_sail_callback, 10)
-        self.algo_rudder_sub = self.create_subscription(
-            Int32, 'algo_rudder', self.algo_rudder_callback, 10)
-        
-        # Subscribers for webserver topics
-        self.webserver_sail_sub = self.create_subscription(
-            Int32, 'webserver_sail', self.webserver_sail_callback, 10)
-        self.webserver_rudder_sub = self.create_subscription(
-            Int32, 'webserver_rudder', self.webserver_rudder_callback, 10)
+        # Create subscribers for all control sources
+        for source in self.control_sources:
+            self.create_subscription(
+                Int32, f'{source}_sail', 
+                lambda msg, src=source: self.sail_callback(msg, src), 10)
+            self.create_subscription(
+                Int32, f'{source}_rudder', 
+                lambda msg, src=source: self.rudder_callback(msg, src), 10)
 
-        # Publishers for multiplexed output (rudder_angle and sail)
+        # Publishers for multiplexed output
         self.rudder_pub = self.create_publisher(Int32, 'rudder_angle', 10)
         self.sail_pub = self.create_publisher(Int32, 'sail', 10)
 
-        # Store the latest values from the topics
-        self.radio_sail = None
-        self.radio_rudder = None
-        self.algo_sail = None
-        self.algo_rudder = None
-        self.webserver_sail = None
-        self.webserver_rudder = None
+        # Timer to publish at a regular interval (10 Hz)
+        self.create_timer(0.1, self.publish_muxed_values)
 
-        # Timer to publish at a regular interval (e.g., 10 Hz)
-        self.timer = self.create_timer(0.1, self.publish_muxed_values)
+    def sail_callback(self, msg, source):
+        self.control_sources[source]['sail'] = msg.data
+        if source == 'webserver' or source == 'controller_app':
+            self.get_logger().info(f'{source} sail angle: {msg.data}')
 
-    def radio_sail_callback(self, msg):
-        self.radio_sail = msg.data
-
-    def radio_rudder_callback(self, msg):
-        self.radio_rudder = msg.data
-
-    def algo_sail_callback(self, msg):
-        self.algo_sail = msg.data
-
-    def algo_rudder_callback(self, msg):
-        self.algo_rudder = msg.data
-
-    def webserver_sail_callback(self, msg):
-        self.get_logger().info(f'Webserver sail angle: {msg.data}')
-        self.webserver_sail = msg.data
-
-    def webserver_rudder_callback(self, msg):
-        self.get_logger().info(f'Webserver rudder angle: {msg.data}')
-        self.webserver_rudder = msg.data
+    def rudder_callback(self, msg, source):
+        self.control_sources[source]['rudder'] = msg.data
+        if source == 'webserver' or source == 'controller_app':
+            self.get_logger().info(f'{source} rudder angle: {msg.data}')
 
     def control_mode_callback(self, msg):
-        if msg.data == 'radio' or msg.data == 'algorithm' or msg.data == 'webserver': 
+        if msg.data in self.control_sources:
             self.control_mode = msg.data
             self.get_logger().info(f'Switched control mode to {msg.data}')
         else:
             self.get_logger().info(f'Invalid control mode request: {msg.data}. Staying in current mode ({self.control_mode})')
 
     def publish_muxed_values(self):
-        # Mux logic: switch between radio or algorithm input based on `use_radio`
-        if self.control_mode == 'radio':
-            # Use radio control
-            if self.radio_sail is not None:
-                sail_msg = Int32()
-                sail_msg.data = self.radio_sail
-                self.sail_pub.publish(sail_msg)
-                self.get_logger().info(f'Published sail angle from radio: {self.radio_sail}')
-
-            if self.radio_rudder is not None:
-                rudder_msg = Int32()
-                rudder_msg.data = self.radio_rudder
-                self.rudder_pub.publish(rudder_msg)
-                self.get_logger().info(f'Published rudder angle from radio: {self.radio_rudder}')
-
-        elif self.control_mode == 'algorithm':
-            # Use algorithm control
-            if self.algo_sail is not None:
-                sail_msg = Int32()
-                sail_msg.data = self.algo_sail
-                self.sail_pub.publish(sail_msg)
-                self.get_logger().info(f'Published sail angle from algorithm: {self.algo_sail}')
-
-            if self.algo_rudder is not None:
-                rudder_msg = Int32()
-                rudder_msg.data = self.algo_rudder
-                self.rudder_pub.publish(rudder_msg)
-                self.get_logger().info(f'Published rudder angle from algorithm: {self.algo_rudder}')
-
-        elif self.control_mode == 'webserver':
-            # Use algorithm control
-            if self.webserver_sail is not None:
-                sail_msg = Int32()
-                sail_msg.data = self.webserver_sail
-                self.sail_pub.publish(sail_msg)
-                self.get_logger().info(f'Published sail angle from webserver: {self.webserver_sail}')
-
-            if self.webserver_rudder is not None:
-                rudder_msg = Int32()
-                rudder_msg.data = self.webserver_rudder
-                self.rudder_pub.publish(rudder_msg)
-                self.get_logger().info(f'Published rudder angle from webserver: {self.webserver_rudder}')
+        # Get current values from the active control source
+        sail_value = self.control_sources[self.control_mode]['sail']
+        rudder_value = self.control_sources[self.control_mode]['rudder']
+        
+        # Publish sail value if available
+        if sail_value is not None:
+            sail_msg = Int32()
+            sail_msg.data = sail_value
+            self.sail_pub.publish(sail_msg)
+            self.get_logger().info(f'Published sail angle from {self.control_mode}: {sail_value}')
+        
+        # Publish rudder value if available
+        if rudder_value is not None:
+            rudder_msg = Int32()
+            rudder_msg.data = rudder_value
+            self.rudder_pub.publish(rudder_msg)
+            self.get_logger().info(f'Published rudder angle from {self.control_mode}: {rudder_value}')
 
 
 def main(args=None):

--- a/src/sailboat_main/sailboat_main/mux/mux_node.py
+++ b/src/sailboat_main/sailboat_main/mux/mux_node.py
@@ -39,13 +39,11 @@ class MuxNode(Node):
 
     def sail_callback(self, msg, source):
         self.control_sources[source]['sail'] = msg.data
-        if source == 'webserver' or source == 'controller_app':
-            self.get_logger().info(f'{source} sail angle: {msg.data}')
+        self.get_logger().info(f'{source} sail angle: {msg.data}')
 
     def rudder_callback(self, msg, source):
         self.control_sources[source]['rudder'] = msg.data
-        if source == 'webserver' or source == 'controller_app':
-            self.get_logger().info(f'{source} rudder angle: {msg.data}')
+        self.get_logger().info(f'{source} rudder angle: {msg.data}')
 
     def control_mode_callback(self, msg):
         if msg.data in self.control_sources:


### PR DESCRIPTION
This PR adds a new option for the mux, which is data from the controller app we are building. However, this file has a lot of duplicate code so I refactored that as well to make it easier to add new mux options.

Refactors the MuxNode class to eliminate significant code duplication by:
- Using a dictionary structure to store all control sources and their values
- Replacing individual callback methods with unified callbacks that take the source as a parameter
- Creating subscriptions dynamically through a loop rather than manually defining each one
- Simplifying the publishing logic to use the same code path for all control sources
