### PR TITLE
Reverse Rudder Mapping

### DIFF
--- a/teensy/src/Control Tasks/ServoControlTask.cpp
+++ b/teensy/src/Control Tasks/ServoControlTask.cpp
@@ -41,7 +41,7 @@ void ServoControlTask::execute()
 
 uint32_t ServoControlTask::tail_to_pwm(uint8_t angle)
 {
-    return map(angle, 0, 50, 45, 55);
+    return map(angle, 0, 50, 55, 45);
 }
 
 uint32_t ServoControlTask::sail_to_pwm(uint8_t angle)


### PR DESCRIPTION
During Lake Test 3, we discovered the rudder mapping was reversed. I fixed the issue locally and uploaded to the teensy with my laptop. The Lake Test 2/3 PR does not include the reversed mapping since I never pushed my changes to the lake-test-2 branch.