### PR TITLE
SSH functionality on startup

### DIFF
--- a/sys/startup.sh
+++ b/sys/startup.sh
@@ -28,11 +28,11 @@ echo "Sourcing environment..." >> "$LOG_FILE"
 source install/setup.bash >> "$LOG_FILE" 2>&1
 
 # Run Ngrok for rosbridge on 9090
-ngrok http 9090 &
+ngrok start --all
 
 # Run ROS
-echo "Starting ROS @ ros.out..." >> "$LOG_FILE"
-ros2 launch sailboat_launch sailboat.launch_sim.py > sys/ros.out
+# echo "Starting ROS @ ros.out..." >> "$LOG_FILE"
+# ros2 launch sailboat_launch sailboat.launch_sim.py > sys/ros.out
 
-echo "ROS application started successfully!" >> "$LOG_FILE"
-exit 0
+# echo "ROS application started successfully!" >> "$LOG_FILE"
+# exit 0


### PR DESCRIPTION
The ngrok.yml in ~./config/ngrok/ngrok.yml was modified to include the web tunnel on 9090 and the ssh TCP tunnel. The tunnels in the yml file are run with ngrok start --all. I had to do it this way because Ngrok only allows one "agent" at a time and multiple tunnels to be routed through a single agent.

