### PR TITLE
Webserver Tweaks

### DIFF
--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -87,8 +87,8 @@
                             <span class="status-value" id="actual-sail-angle-value">N/A</span>
                         </div>
                         <div class="status-row">
-                            <span class="status-label">Actual Tail Angle: </span>
-                            <span class="status-value" id="actual-tail-angle-value">N/A</span>
+                            <span class="status-label">Actual Rudder Angle: </span>
+                            <span class="status-value" id="actual-rudder-angle-value">N/A</span>
                         </div>
                         <div class="status-row">
                             <span class="status-label">Dropped Packets: </span>
@@ -199,12 +199,12 @@
                             <span class="status-value" id="heading-dir-value">N/A</span>
                         </div>
                         <div class="status-row">
-                            <span class="status-label">Current Destination:</span>
-                            <span class="status-value" id="curr-dest-value">N/A</span>
+                            <span class="status-label">Heading Difference:</span>
+                            <span class="status-value" id="diff-value">N/A</span>
                         </div>
                         <div class="status-row">
-                            <span class="status-label">Difference:</span>
-                            <span class="status-value" id="diff-value">N/A</span>
+                            <span class="status-label">Current Destination:</span>
+                            <span class="status-value" id="curr-dest-value">N/A</span>
                         </div>
                         <div class="status-row">
                             <span class="status-label">Distance to Destination:</span>
@@ -349,7 +349,7 @@
                     </div>
                 </div>
             </div>
-            <div id="sailboat-angle-dashboard">
+            <!-- <div id="sailboat-angle-dashboard">
                 <div class="dial">
                     <h3>Sail Angle</h3>
                     <div id="dial-container-sail"></div>
@@ -365,7 +365,7 @@
                     <div id="dial-container-head"></div>
                     <p id="heading-value-dial">Heading Angle: N/A°</p>
                 </div>
-            </div>
+            </div> -->
         </div>
     </div>
     

--- a/src/webserver/modules/rosConnection.js
+++ b/src/webserver/modules/rosConnection.js
@@ -39,10 +39,14 @@ export class ROSConnection {
         // Individual sail control
         document.getElementById('sail-submit').addEventListener('click', () => {
             const sailAngle = document.getElementById('sail-input');
-            
+
             if (sailAngle && sailAngle.value) {
+                // Clamp sail angle to [0, 90]
+                let angle = parseInt(sailAngle.value, 10);
+                angle = Math.max(0, Math.min(90, angle));
+            
                 const sailMessage = new ROSLIB.Message({
-                    data: parseInt(sailAngle.value, 10)
+                    data: angle
                 });
                 
                 if (this.webserverSailTopic) {
@@ -63,8 +67,12 @@ export class ROSConnection {
             const rudderAngle = document.getElementById('rudder-input');
             
             if (rudderAngle && rudderAngle.value) {
+                // Clamp rudder angle to [-25, 25]
+                let angle = parseInt(rudderAngle.value, 10);
+                angle = Math.max(-25, Math.min(25, angle));
+
                 const rudderMessage = new ROSLIB.Message({
-                    data: parseInt(rudderAngle.value, 10)
+                    data: angle
                 });
                 
                 if (this.webserverRudderTopic) {
@@ -227,7 +235,8 @@ export class ROSConnection {
             throttle_rate: this.BASE_THROTTLE_RATE,
         });
         actualRudderAngleTopic.subscribe((message) => {
-            updateValue('actual-tail-angle-value', message.data);
+            // Update angle, shift from [0,50] to [-25,25]
+            updateValue('actual-rudder-angle-value', message.data - 25);
             if (this.dialManager) {
                 this.dialManager.updateTailAngle(message.data, "actual-tail-angle-dial");
             }


### PR DESCRIPTION
- comment out the dials on the webserver (I don’t think their useful anymore)
- The “Actual Rudder Angle” field should be subtracted by 25. Right now its in range 0 - 50, so I subtract the value given by ROS by 25 to get something from -25 to 25
- Change the html to say heading difference not just difference (in algo debug)
- In webserver control mode, the “Rudder Angle” input should be clamped to be from -25 to 25
- In webserver control mode, the  “Sail angle” should be clamped from 0 to 90
