### PR TITLE
Event Mgmt & Station Keeping 

### DIFF
--- a/src/sailboat_interface/CMakeLists.txt
+++ b/src/sailboat_interface/CMakeLists.txt
@@ -17,9 +17,12 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/SailTail.msg"
-  "srv/Waypoint.srv"
   "msg/AlgoDebug.msg"
+  "msg/Mode.msg"
+  "msg/StationRectangle.msg"
 
+  "srv/Waypoint.srv"
+  "srv/SetModeWithParams.srv"
   DEPENDENCIES std_msgs sensor_msgs # Add packages that above messages depend on, in this case geometry_msgs for Sphere.msg
 )
 

--- a/src/sailboat_interface/msg/Mode.msg
+++ b/src/sailboat_interface/msg/Mode.msg
@@ -1,0 +1,1 @@
+string mode

--- a/src/sailboat_interface/msg/StationRectangle.msg
+++ b/src/sailboat_interface/msg/StationRectangle.msg
@@ -1,0 +1,4 @@
+# StationRectangle.msg
+# Represents a rectangle defined by four GPS corners (in order)
+
+geometry_msgs/Point[4] corners

--- a/src/sailboat_interface/msg/StationRectangle.msg
+++ b/src/sailboat_interface/msg/StationRectangle.msg
@@ -1,4 +1,6 @@
 # StationRectangle.msg
 # Represents a rectangle defined by four GPS corners (in order)
+# The last two points are the points to sail between when inside the rectangle
 
-geometry_msgs/Point[4] corners
+geometry_msgs/Point[4] corners  # The four corners of the rectangle
+geometry_msgs/Point[2] sail_points  # The two points to sail between when inside the rectangle

--- a/src/sailboat_interface/srv/SetModeWithParams.srv
+++ b/src/sailboat_interface/srv/SetModeWithParams.srv
@@ -1,0 +1,13 @@
+string mode  # "manual", "station_keeping", or "search"
+
+# Parameters vary by mode:
+
+# For "station_keeping", fill station_rect_points (in order)
+geometry_msgs/Point[] station_rect_points  # 4 lat-long-alt points (alt=0)
+
+# For "search", provide a center point
+geometry_msgs/Point search_center_point  # lat-long-alt (alt=0)
+
+---
+bool success
+string message

--- a/src/sailboat_launch/launch/sailboat.launch.py
+++ b/src/sailboat_launch/launch/sailboat.launch.py
@@ -83,6 +83,22 @@ def generate_launch_description():
       namespace='sailbot',
       parameters=[config]
    )
+
+   mode_manager_cmd = Node(
+      package='sailbot_events',
+      executable='mode_manager',
+      name='mode_manager',
+      namespace='sailbot',
+      parameters=[config]
+   )
+
+   station_keeping_cmd = Node(
+      package='sailbot_events',
+      executable='station_keeping',
+      name='station_keeping',
+      namespace='sailbot',
+      parameters=[config]
+   )
    
    ld = LaunchDescription()
 
@@ -94,6 +110,10 @@ def generate_launch_description():
    ld.add_action(main_algo_cmd)
    ld.add_action(trim_sail_cmd)
    ld.add_action(waypoint_service_cmd)
+
+   # Event Drivers
+   ld.add_action(mode_manager_cmd)
+   ld.add_action(station_keeping_cmd)
 
    # Togglable rc control
    ld.add_action(radio_cmd)

--- a/src/sailboat_launch/launch/sailboat_hw_sim.launch.py
+++ b/src/sailboat_launch/launch/sailboat_hw_sim.launch.py
@@ -77,6 +77,22 @@ def generate_launch_description():
       parameters=[config]
    )
 
+   mode_manager_cmd = Node(
+      package='sailbot_events',
+      executable='mode_manager',
+      name='mode_manager',
+      namespace='sailbot',
+      parameters=[config]
+   )
+
+   station_keeping_cmd = Node(
+      package='sailbot_events',
+      executable='station_keeping',
+      name='station_keeping',
+      namespace='sailbot',
+      parameters=[config]
+   )
+
    rosbridge_node = Node(
         package='rosbridge_server',
         executable='rosbridge_websocket',
@@ -102,6 +118,10 @@ def generate_launch_description():
    # Togglable rc control
    ld.add_action(radio_cmd) # SIM
    ld.add_action(mux_cmd)
+
+   # Event algos
+   ld.add_action(mode_manager_cmd)
+   ld.add_action(station_keeping_cmd)
 
    # Telemetry
    ld.add_action(rosbridge_node)

--- a/src/sailbot_events/sailbot_events/event_driver/mode_manager.py
+++ b/src/sailbot_events/sailbot_events/event_driver/mode_manager.py
@@ -29,7 +29,7 @@ class ModeManagerNode(Node):
 
         # Publish initial mode
         self.publish_current_mode()
-        self.get_logger().info(f"[ModeManager] Initialized in mode '{self.current_mode}'")
+        self.get_logger().info(f"Initialized in mode '{self.current_mode}'")
 
     def publish_current_mode(self):
         msg = String()

--- a/src/sailbot_events/sailbot_events/event_driver/mode_manager.py
+++ b/src/sailbot_events/sailbot_events/event_driver/mode_manager.py
@@ -1,0 +1,96 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from sensor_msgs.msg import NavSatFix
+from geometry_msgs.msg import Point
+from sailboat_interface.srv import SetModeWithParams
+from sailboat_interface.msg import StationRectangle
+
+ALLOWED_MODES = {"manual", "station_keeping", "search"}
+
+class ModeManagerNode(Node):
+    def __init__(self):
+        super().__init__('mode_manager')
+
+        # Current mode and its parameters
+        self.current_mode = "manual"
+        self.station_rect = []  # List of 4 geometry_msgs/Point
+        self.search_center = None  # geometry_msgs/Point
+
+        # Publisher for mode name
+        self.mode_pub = self.create_publisher(String, 'current_mode', 10)
+        # Publisher for station rectangle message
+        self.station_rect_pub = self.create_publisher(StationRectangle, 'station_rectangle', 10)
+        # Publisher for search center point
+        self.search_center_pub = self.create_publisher(Point, 'search_center_point', 10)
+
+        # Service to set mode and parameters
+        self.set_mode_srv = self.create_service(SetModeWithParams, 'set_mode', self.set_mode_callback)
+
+        # Publish initial mode
+        self.publish_current_mode()
+        self.get_logger().info(f"[ModeManager] Initialized in mode '{self.current_mode}'")
+
+    def publish_current_mode(self):
+        msg = String()
+        msg.data = self.current_mode
+        self.mode_pub.publish(msg)
+
+    def publish_station_rect(self):
+        msg = StationRectangle()
+        msg.corners = self.station_rect
+        self.station_rect_pub.publish(msg)
+
+    def publish_search_center(self):
+        if self.search_center:
+            self.search_center_pub.publish(self.search_center)
+
+    def set_mode_callback(self, request, response):
+        mode = request.mode.lower()
+
+        if mode not in ALLOWED_MODES:
+            response.success = False
+            response.message = f"Invalid mode '{mode}'. Allowed: {list(ALLOWED_MODES)}"
+            self.get_logger().warn(response.message)
+            return response
+
+        # If switching to same mode, still publish parameters
+        self.current_mode = mode
+
+        if mode == "station_keeping":
+            # Expect exactly 4 points
+            if len(request.station_rect_points) != 4:
+                response.success = False
+                response.message = "Station keeping mode requires exactly 4 points."
+                return response
+            self.station_rect = request.station_rect_points
+            self.get_logger().info(f"[ModeManager] Station keeping with 4 rectangle points.")
+
+        elif mode == "search":
+            self.search_center = request.search_center_point
+            self.get_logger().info(f"[ModeManager] Search mode with center point ({self.search_center.y}, {self.search_center.x})")
+
+        elif mode == "manual":
+            # Clear parameters
+            self.station_rect = []
+            self.search_center = None
+            self.get_logger().info("[ModeManager] Manual mode activated.")
+
+        # Publish new mode and parameters
+        self.publish_current_mode()
+        if mode == "station_keeping":
+            self.publish_station_rect()
+        elif mode == "search":
+            self.publish_search_center()
+
+        response.success = True
+        response.message = f"Switched to '{mode}' mode and parameters published."
+        return response
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ModeManagerNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/src/sailbot_events/sailbot_events/event_driver/station_keeping.py
+++ b/src/sailbot_events/sailbot_events/event_driver/station_keeping.py
@@ -158,7 +158,7 @@ class StationKeepingNode(Node):
         self.get_logger().info(f'Sending waypoints to queue: {points}')
         if isinstance(points[0], UTMPoint):
             points = [pt.to_latlon() for pt in points]
-        formatted = ';'.join(f'{pt.longitude},{pt.latitude}' for pt in points)
+        formatted = ';'.join(f'{pt.latitude},{pt.longitude}' for pt in points)
 
         client = self.create_client(Waypoint, 'mutate_waypoint_queue')
         if not client.wait_for_service(timeout_sec=3.0):

--- a/src/sailbot_events/sailbot_events/event_driver/station_keeping.py
+++ b/src/sailbot_events/sailbot_events/event_driver/station_keeping.py
@@ -1,0 +1,194 @@
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String, Int32
+from sensor_msgs.msg import NavSatFix
+from geometry_msgs.msg import Point
+from your_package_name.srv import SetModeWithParams, Waypoint
+from your_package_name.msg import StationRectangle
+import math
+import utm
+import time
+from threading import Timer
+
+class UTMPoint:
+    def __init__(self, easting, northing, zone_number, zone_letter):
+        self.easting = easting
+        self.northing = northing
+        self.zone_number = zone_number
+        self.zone_letter = zone_letter
+
+    def to_latlon(self):
+        latitude, longitude = utm.to_latlon(
+            self.easting, self.northing, self.zone_number, self.zone_letter)
+        return LatLongPoint(latitude, longitude)
+
+    def to_navsatfix_msg(self):
+        lat_long = self.to_latlon()
+        msg = NavSatFix()
+        msg.latitude = lat_long.latitude
+        msg.longitude = lat_long.longitude
+        return msg
+
+    def distance_to(self, other):
+        assert self.zone_number == other.zone_number
+        return math.dist((self.easting, self.northing), (other.easting, other.northing))
+
+    def __sub__(self, other):
+        return UTMPoint(
+            self.easting - other.easting,
+            self.northing - other.northing,
+            self.zone_number,
+            self.zone_letter
+        )
+
+    def __add__(self, other):
+        return UTMPoint(
+            self.easting + other.easting,
+            self.northing + other.northing,
+            self.zone_number,
+            self.zone_letter
+        )
+
+class LatLongPoint:
+    def __init__(self, latitude, longitude):
+        self.latitude = latitude
+        self.longitude = longitude
+
+    def to_utm(self):
+        x, y, zone_number, zone_letter = utm.from_latlon(self.latitude, self.longitude)
+        return UTMPoint(x, y, zone_number, zone_letter)
+
+class StationKeepingNode(Node):
+    def __init__(self):
+        super().__init__('station_keeping')
+
+        self.curr_location = None
+        self.wind_angle_deg = None
+        self.rectangle_corners = []
+        self.in_rectangle = False
+        self.timer_started = False
+        self.current_mode = 'manual'
+
+        self.subscription_curr_loc = self.create_subscription(
+            NavSatFix, '/gps', self.curr_gps_callback, 10)
+        self.subscription_wind_direction = self.create_subscription(
+            Int32, 'wind', self.wind_callback, 10)
+        self.mode_sub = self.create_subscription(
+            String, '/current_mode', self.mode_callback, 10)
+        self.rect_sub = self.create_subscription(
+            StationRectangle, '/station_rectangle', self.station_rectangle_callback, 10)
+
+        self.timer_5min = None
+        self.timer_30sec = self.create_timer(
+            30.0, self.update_perpendicular_waypoints)
+
+    def station_rectangle_callback(self, msg):
+        self.rectangle_corners = [LatLongPoint(p.y, p.x).to_utm() for p in msg.corners]
+        self.get_logger().info("Received updated station-keeping rectangle corners.")
+
+    def mode_callback(self, msg):
+        self.current_mode = msg.data
+        if self.current_mode == 'station_keeping' and self.rectangle_corners:
+            self.get_logger().info("Station keeping mode activated.")
+            center = self.compute_center()
+            self.send_waypoints_to_queue([center])
+
+    def curr_gps_callback(self, msg):
+        self.curr_location = LatLongPoint(
+            msg.latitude, msg.longitude).to_utm()
+        if self.current_mode == 'station_keeping' and not self.timer_started:
+            if self.is_inside_rectangle(self.curr_location):
+                self.in_rectangle = True
+                self.timer_started = True
+                self.get_logger().info("Entered rectangle. Starting 5 min timer.")
+                self.timer_5min = Timer(300.0, self.exit_rectangle)
+                self.timer_5min.start()
+
+    def wind_callback(self, msg):
+        self.wind_angle_deg = msg.data
+
+    def compute_center(self):
+        e = sum(p.easting for p in self.rectangle_corners) / 4
+        n = sum(p.northing for p in self.rectangle_corners) / 4
+        zone = self.rectangle_corners[0]
+        return UTMPoint(e, n, zone.zone_number, zone.zone_letter)
+
+    def is_inside_rectangle(self, point):
+        xs = [p.easting for p in self.rectangle_corners]
+        ys = [p.northing for p in self.rectangle_corners]
+        return min(xs) <= point.easting <= max(xs) and min(ys) <= point.northing <= max(ys)
+
+    def update_perpendicular_waypoints(self):
+        if self.current_mode != 'station_keeping' or not self.in_rectangle or self.wind_angle_deg is None:
+            return
+
+        center = self.compute_center()
+        bearing_rad = math.radians((self.wind_angle_deg + 90) % 360)
+        dx = 5 * math.cos(bearing_rad)
+        dy = 5 * math.sin(bearing_rad)
+
+        wp1 = UTMPoint(
+            center.easting + dx, center.northing + dy,
+            center.zone_number, center.zone_letter)
+        wp2 = UTMPoint(
+            center.easting - dx, center.northing - dy,
+            center.zone_number, center.zone_letter)
+
+        self.send_waypoints_to_queue([wp1, wp2])
+
+    def send_waypoints_to_queue(self, points):
+        if isinstance(points[0], UTMPoint):
+            points = [pt.to_latlon() for pt in points]
+        formatted = ';'.join(f'{pt.longitude},{pt.latitude}' for pt in points)
+
+        client = self.create_client(Waypoint, 'mutate_waypoint_queue')
+        if not client.wait_for_service(timeout_sec=3.0):
+            self.get_logger().error('Waypoint queue service not available')
+            return
+
+        req = Waypoint.Request()
+        req.command = 'set'
+        req.argument = formatted
+        fut = client.call_async(req)
+        fut.add_done_callback(lambda f: self._handle_wp_response(f))
+
+    def _handle_wp_response(self, future):
+        res = future.result()
+        if res.success:
+            self.get_logger().info(f'Waypoint queue updated: {res.message}')
+        else:
+            self.get_logger().warn(f'Failed to update queue: {res.message}')
+
+    def exit_rectangle(self):
+        self.get_logger().info("5 min timer done. Exiting station keeping.")
+        if not self.curr_location:
+            return
+        best_point = None
+        min_dist = float('inf')
+        corners = self.rectangle_corners
+        for i in range(len(corners)):
+            a = corners[i]
+            b = corners[(i + 1) % len(corners)]
+            proj = self.project_to_segment(self.curr_location, a, b)
+            d = proj.distance_to(self.curr_location)
+            if d < min_dist:
+                min_dist = d
+                best_point = proj
+        self.send_waypoints_to_queue([best_point])
+
+    def project_to_segment(self, p, a, b):
+        ap = p - a
+        ab = b - a
+        ab_len2 = ab.easting**2 + ab.northing**2
+        t = max(0, min(1, (ap.easting * ab.easting + ap.northing * ab.northing) / ab_len2))
+        proj_e = a.easting + ab.easting * t
+        proj_n = a.northing + ab.northing * t
+        return UTMPoint(proj_e, proj_n, a.zone_number, a.zone_letter)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = StationKeepingNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/src/sailbot_events/setup.py
+++ b/src/sailbot_events/setup.py
@@ -22,6 +22,8 @@ setup(
         'console_scripts': [
             'event_driver = sailbot_events.event_driver.event_driver_node:main',
             'waypoint_service = sailbot_events.event_driver.waypoint_service:main',
+            'mode_manager = sailbot_events.event_driver.mode_manager:main',
+            'station_keeping = sailbot_events.event_driver.station_keeping:main',
         ],
     },
 )

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -385,6 +385,20 @@
                                     <input type="number" id="sk-corner4-lon" placeholder="Longitude" step="any" required>
                                 </div>
                             </div>
+                            <div class="status-row-input second">
+                                <span class="status-label">Sail Point 1:</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-sail1-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-sail1-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
+                            <div class="status-row-input second">
+                                <span class="status-label">Sail Point 2:</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-sail2-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-sail2-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
                             <div class="button-group">
                                 <button type="button" id="submit-station-rectangle">Activate Station Keeping</button>
                             </div>

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -349,6 +349,49 @@
                     </div>
                 </div>
             </div>
+            <div class="table-container">
+                <div class="table-heading" onclick="toggleSection(this)">
+                    <h1>Station Keeping <span class="toggle-icon">+</span></h1>
+                </div>
+                <div class="collapsible-section hidden">
+                    <div class="waypoint-buoy-container">
+                        <!-- Input fields for each corner -->
+                        <div class="waypoint-buoy-table">
+                            <div class="status-row-input second">
+                                <span class="status-label">Corner 1 (lat, lon):</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-corner1-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-corner1-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
+                            <div class="status-row-input second">
+                                <span class="status-label">Corner 2 (lat, lon):</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-corner2-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-corner2-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
+                            <div class="status-row-input second">
+                                <span class="status-label">Corner 3 (lat, lon):</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-corner3-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-corner3-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
+                            <div class="status-row-input second">
+                                <span class="status-label">Corner 4 (lat, lon):</span>
+                                <div class="input-group">
+                                    <input type="number" id="sk-corner4-lat" placeholder="Latitude" step="any" required>
+                                    <input type="number" id="sk-corner4-lon" placeholder="Longitude" step="any" required>
+                                </div>
+                            </div>
+                            <div class="button-group">
+                                <button type="button" id="submit-station-rectangle">Activate Station Keeping</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div id="sailboat-angle-dashboard">
                 <div class="dial">
                     <h3>Sail Angle</h3>
@@ -368,7 +411,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Load the modular JavaScript -->
     <script type="module" src="main.js"></script>
     

--- a/src/webserver/index.html
+++ b/src/webserver/index.html
@@ -388,6 +388,9 @@
                             <div class="button-group">
                                 <button type="button" id="submit-station-rectangle">Activate Station Keeping</button>
                             </div>
+                            <div class="button-group">
+                                <button type="button" id="cancel-station-keeping">End Station Keeping (Manual Mode)</button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/webserver/modules/dialManager.js
+++ b/src/webserver/modules/dialManager.js
@@ -155,7 +155,7 @@ export class DialManager {
                 .duration(500)
                 .attr("transform", `rotate(${angle - 90})`);
         }
-        document.getElementById(id).innerText = "Angle: " + angle;
+        // document.getElementById(id).innerText = "Angle: " + angle;
     }
 
     updateTailAngle(angle, id) {
@@ -164,7 +164,7 @@ export class DialManager {
                 .duration(500)
                 .attr("transform", `rotate(${angle - 90})`);
         }
-        document.getElementById(id).innerText = "Angle: " + angle;
+        // document.getElementById(id).innerText = "Angle: " + angle;
     }
 
     updateHeadAngle(angle, id) {
@@ -173,6 +173,6 @@ export class DialManager {
                 .duration(500)
                 .attr("transform", `rotate(${angle - 90})`);
         }
-        document.getElementById(id).innerText = "Angle: " + angle;
+        // document.getElementById(id).innerText = "Angle: " + angle;
     }
 }

--- a/src/webserver/modules/rosConnection.js
+++ b/src/webserver/modules/rosConnection.js
@@ -91,6 +91,7 @@ export class ROSConnection {
 
         // Station Keeping Mode
         document.getElementById('submit-station-rectangle').addEventListener('click', () => {
+            console.log("Submitting station keeping rectangle");
             const latLonPairs = [1, 2, 3, 4].map(i => {
                 const lat = parseFloat(document.getElementById(`sk-corner${i}-lat`).value);
                 const lon = parseFloat(document.getElementById(`sk-corner${i}-lon`).value);
@@ -101,17 +102,36 @@ export class ROSConnection {
                 alert("Please enter all 4 corners with valid latitude and longitude values.");
                 return;
             }
-
+            
+            console.log("Station keeping rectangle points:", latLonPairs);
             const request = new ROSLIB.ServiceRequest({
                 mode: "station_keeping",
                 station_rect_points: latLonPairs,
                 search_center_point: { x: 0.0, y: 0.0, z: 0.0 } // dummy value
             });
 
+
             this.setModeService.callService(request, (result) => {
                 if (result.success) {
                     console.log("Mode set to station_keeping:", result.message);
-                    this.publishControlMode("station_keeping");  // Optional
+                } else {
+                    alert("Failed to set mode: " + result.message);
+                }
+            });
+        });
+
+        // Cancel Station Keeping Mode
+        document.getElementById('cancel-station-keeping').addEventListener('click', () => {
+            if (!this.setModeService) {
+                alert("ROS not connected. Please connect to ROS first.");
+                return;
+            }
+            const request = new ROSLIB.ServiceRequest({
+                mode: "manual"
+            });
+            this.setModeService.callService(request, (result) => {
+                if (result.success) {
+                    console.log("Mode set to manual:", result.message);
                 } else {
                     alert("Failed to set mode: " + result.message);
                 }
@@ -333,7 +353,7 @@ export class ROSConnection {
         // Initialize set mode service
         this.setModeService = new ROSLIB.Service({
             ros: this.ros,
-            name: '/set_mode',
+            name: 'sailbot/set_mode',
             serviceType: 'sailboat_interface/srv/SetModeWithParams'
         });
 

--- a/src/webserver/modules/rosConnection.js
+++ b/src/webserver/modules/rosConnection.js
@@ -98,18 +98,32 @@ export class ROSConnection {
                 return { x: lon, y: lat, z: 0.0 };  // ROS Point: x=lon, y=lat
             });
 
-            if (latLonPairs.some(pt => isNaN(pt.x) || isNaN(pt.y))) {
-                alert("Please enter all 4 corners with valid latitude and longitude values.");
+            // Add sail points
+            const sailPoint1 = {
+                x: parseFloat(document.getElementById('sk-sail1-lon').value),
+                y: parseFloat(document.getElementById('sk-sail1-lat').value),
+                z: 0.0
+            };
+            const sailPoint2 = {
+                x: parseFloat(document.getElementById('sk-sail2-lon').value),
+                y: parseFloat(document.getElementById('sk-sail2-lat').value),
+                z: 0.0
+            };
+
+            if (latLonPairs.some(pt => isNaN(pt.x) || isNaN(pt.y)) || 
+                isNaN(sailPoint1.x) || isNaN(sailPoint1.y) ||
+                isNaN(sailPoint2.x) || isNaN(sailPoint2.y)) {
+                alert("Please enter all points with valid latitude and longitude values.");
                 return;
             }
             
             console.log("Station keeping rectangle points:", latLonPairs);
+            console.log("Sail points:", [sailPoint1, sailPoint2]);
             const request = new ROSLIB.ServiceRequest({
                 mode: "station_keeping",
-                station_rect_points: latLonPairs,
+                station_rect_points: [...latLonPairs, sailPoint1, sailPoint2],
                 search_center_point: { x: 0.0, y: 0.0, z: 0.0 } // dummy value
             });
-
 
             this.setModeService.callService(request, (result) => {
                 if (result.success) {


### PR DESCRIPTION
## Event Mgmt 

### Topics
- `/current_mode` → `std_msgs/String`: current mode of operation (e.g. station_keeping, search, manual, or others in the future). 
- `/station_rectangle` → `sailboat_interface/msg/StationRectangle`: 4 corners of rectangle

###  Mode Manager and SetModeWithParams Service

The `mode_manager` node handles switching between high-level behaviors like `"manual"`, `"station_keeping"`, and `"search"`. Only one mode can be active at a time.

When a mode is set via the `/set_mode` service, the manager:
- Publishes the current mode on `/current_mode` (`std_msgs/String`)
- Publishes associated parameters, like rectangle corners for station keeping, on dedicated topics (e.g., `/station_rectangle`). **For search, the topic is called `search_center_point`.**

#### Service: `SetModeWithParams.srv`

```srv
string mode  # "manual", "station_keeping", "search"
geometry_msgs/Point[] station_rect_points  # for station_keeping
geometry_msgs/Point search_center_point    # for search
--- # Returns:
bool success
string message
```
---

### Station Keeping Impl: `station_keeping.py`

This node handles autonomous "station keeping" behavior for the sailboat. It:
- Waits for the `current_mode` topic to be `"station_keeping"`
- Subscribes to the `/station_rectangle` topic (custom `StationRectangle.msg`) to get 4 corners
- Computes the **center** of the rectangle and sends it to the waypoint queue using the `mutate_waypoint_queue` service (`Waypoint.srv`)
- Listens to `/gps` and starts a **5-minute timer** once the boat enters the rectangle
- Every **30 seconds**, computes and updates 2 waypoints **perpendicular to wind** from `/wind` topic (`std_msgs/Int32`)
- After 5 minutes, exits by finding the **closest point on the rectangle border** and sends it as the next waypoint
- Resets and cancels the behavior if mode switches away from `station_keeping`

#### HTML
Added UI inputs for 4 corners (latitude + longitude each) under a **"Station Keeping"** section, with a **Submit** button, as well as a **Cancel** button which switches mode back to manual.

#### JS (rosConnection.js)
- Added a `setModeService` client for `/set_mode` (`SetModeWithParams.srv`)
- On Submit:
  - Reads the 4 corners
  - Constructs a service request with:
    ```
    {
      mode: "station_keeping",
      station_rect_points: [{x: lon, y: lat, z: 0}, ...],
    }
    ```
  - Sends the service call and publishes `control_mode`

<img width="513" alt="image" src="https://github.com/user-attachments/assets/cec0b080-4a6b-40a7-b363-0704b47e650d" />
